### PR TITLE
Use IPython LTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ transitfeed==1.2.14
 requests
 celery
 pymongo
-ipython
+ipython==5.5.0


### PR DESCRIPTION
Version 6.x requires python >= 3.3